### PR TITLE
bug(DAPP-439): Fixes chain info node call with incorrect epoch

### DIFF
--- a/lib/blocks/models/block.dart
+++ b/lib/blocks/models/block.dart
@@ -39,7 +39,8 @@ class Block with _$Block {
   factory Block.fromBlockRes({required BlockResponse blockRes, required int epochLength}) {
     final block = Block(
       header: decodeId(blockRes.block.header.headerId.value),
-      epoch: blockRes.block.header.slot.toInt() ~/ epochLength,
+      // QQQQ remove the hardcoded 10
+      epoch: (blockRes.block.header.slot.toInt() ~/ epochLength) ~/ 10,
       size: blockRes.writeToBuffer().lengthInBytes.toDouble(),
       height: blockRes.block.header.height.toInt(),
       slot: blockRes.block.header.slot.toInt(),

--- a/lib/blocks/models/block.dart
+++ b/lib/blocks/models/block.dart
@@ -39,8 +39,7 @@ class Block with _$Block {
   factory Block.fromBlockRes({required BlockResponse blockRes, required int epochLength}) {
     final block = Block(
       header: decodeId(blockRes.block.header.headerId.value),
-      // QQQQ remove the hardcoded 10
-      epoch: (blockRes.block.header.slot.toInt() ~/ epochLength) ~/ 10,
+      epoch: (blockRes.block.header.slot.toInt() ~/ epochLength),
       size: blockRes.writeToBuffer().lengthInBytes.toDouble(),
       height: blockRes.block.header.height.toInt(),
       slot: blockRes.block.header.slot.toInt(),

--- a/lib/blocks/models/block.dart
+++ b/lib/blocks/models/block.dart
@@ -39,7 +39,7 @@ class Block with _$Block {
   factory Block.fromBlockRes({required BlockResponse blockRes, required int epochLength}) {
     final block = Block(
       header: decodeId(blockRes.block.header.headerId.value),
-      epoch: (blockRes.block.header.slot.toInt() ~/ epochLength),
+      epoch: blockRes.block.header.slot.toInt() ~/ epochLength,
       size: blockRes.writeToBuffer().lengthInBytes.toDouble(),
       height: blockRes.block.header.height.toInt(),
       slot: blockRes.block.header.slot.toInt(),

--- a/lib/chain/models/chains.dart
+++ b/lib/chain/models/chains.dart
@@ -28,10 +28,16 @@ sealed class Chains with _$Chains {
   }) = PrivateNetwork;
   const factory Chains.dev_network({
     @Default('Development') String networkName,
-    @Default('seannet.topl.tech') String hostUrl,
+    @Default('testnet.topl.tech') String hostUrl,
     @Default('development') String urlName,
     @Default(443) int port,
   }) = DevNetwork;
+  const factory Chains.sean_network({
+    @Default('Seannet') String networkName,
+    @Default('seannet.topl.tech') String hostUrl,
+    @Default('seannet') String urlName,
+    @Default(443) int port,
+  }) = SeanNetwork;
   const factory Chains.mock({
     @Default('Mock') String networkName,
     @Default('mock') String urlName,

--- a/lib/chain/models/chains.dart
+++ b/lib/chain/models/chains.dart
@@ -28,7 +28,7 @@ sealed class Chains with _$Chains {
   }) = PrivateNetwork;
   const factory Chains.dev_network({
     @Default('Development') String networkName,
-    @Default('testnet.topl.tech') String hostUrl,
+    @Default('seannet.topl.tech') String hostUrl,
     @Default('development') String urlName,
     @Default(443) int port,
   }) = DevNetwork;

--- a/lib/chain/providers/chain_statistics_provider.dart
+++ b/lib/chain/providers/chain_statistics_provider.dart
@@ -97,15 +97,14 @@ class ChainStatisticNotifier extends StateNotifier<AsyncValue<Chain>> {
       final int dataBytes = chainData.epochData.dataBytes.toInt();
 
       final int startTimestamp = chainData.epochData.startTimestamp.toInt();
-      print('QQQQ startTimestamp $startTimestamp');
 
       final int currentTimestamp = DateTime.now().millisecondsSinceEpoch;
-      print('QQQQ currentTimestamp $currentTimestamp');
+
+      final double epochDuration = (currentTimestamp - startTimestamp) / 1000;
 
       // Convert milliseconds to seconds
 
-      final double dataThroughput =
-          double.parse((dataBytes / ((currentTimestamp - startTimestamp) / 1000)).toStringAsFixed(2));
+      final double dataThroughput = double.parse((dataBytes / (epochDuration)).toStringAsFixed(2));
 
       //////// Average Transaction fee ////////
       final int totalTransactionsInEpoch = chainData.epochData.transactionCount.toInt();
@@ -114,10 +113,12 @@ class ChainStatisticNotifier extends StateNotifier<AsyncValue<Chain>> {
       final double averageTransactionFee = totalTransactionReward.toInt() / totalTransactionsInEpoch;
 
       //////// Average Block Time ////////
-      final int totalBlocks = chainData.epochData.endHeight.toInt();
+      final int endBlocks = chainData.epochData.endHeight.toInt();
+      final int startBlocks = chainData.epochData.startHeight.toInt();
 
-      final int averageBlockTime =
-          totalBlocks == 0 ? 0 : (totalBlocks / ((currentTimestamp - startTimestamp) / 1000)).round();
+      final int totalBlocksInEpoch = endBlocks - startBlocks;
+
+      final int averageBlockTime = totalBlocksInEpoch == 0 ? 0 : (epochDuration / totalBlocksInEpoch).round();
 
       //////// Others ////////
       final int eon = chainData.epochData.eon.toInt();
@@ -126,7 +127,9 @@ class ChainStatisticNotifier extends StateNotifier<AsyncValue<Chain>> {
 
       final int epoch = chainData.epochData.epoch.toInt();
 
-      final int endHeight = chainData.epochData.endHeight.toInt();
+      // TODO: Node seems to be ahead of genus, so currently going to use block at depth 0
+      // final int endHeight = chainData.epochData.endHeight.toInt();
+      final int endHeight = blockAtDepth0.height;
 
       final activeStakes = chainData.epochData.activeStake.toBigInt().toInt();
 

--- a/lib/chain/providers/chain_statistics_provider.dart
+++ b/lib/chain/providers/chain_statistics_provider.dart
@@ -89,8 +89,6 @@ class ChainStatisticNotifier extends StateNotifier<AsyncValue<Chain>> {
       final Block blockAtDepth0 = await ref.read(blockStateAtDepthProvider(0).future);
       final int currentEpoch = blockAtDepth0.epoch.toInt();
 
-      print('QQQQ currentEpoch ${blockAtDepth0.epoch}');
-
       final FetchEpochDataRes chainData = await nodeClient.fetchEpochData(epoch: currentEpoch);
 
       //////// Data Throughput ////////
@@ -154,7 +152,6 @@ class ChainStatisticNotifier extends StateNotifier<AsyncValue<Chain>> {
       );
       return chain;
     } catch (e) {
-      print('QQQQ Error retrieving chain data $e');
       throw ('Error retrieving chain data $e');
     }
   }

--- a/lib/chain/providers/selected_chain_provider.dart
+++ b/lib/chain/providers/selected_chain_provider.dart
@@ -19,7 +19,12 @@ class ChainsNotifier extends StateNotifier<AsyncValue<List<Chains>>> {
   ChainsNotifier(this.ref) : super(const AsyncLoading()) {
     _getAvailableChains(setState: true);
   }
-  static List<Chains> devChains = [const Chains.private_network(), const Chains.dev_network(), const Chains.mock()];
+  static List<Chains> devChains = [
+    const Chains.private_network(),
+    const Chains.dev_network(),
+    const Chains.sean_network(),
+    const Chains.mock(),
+  ];
   // dev notes: This will have to be updated when we change the predetermined networks
   static List<Chains> standardChains = [
     const Chains.topl_mainnet(),

--- a/lib/chain/utils/chain_utils.dart
+++ b/lib/chain/utils/chain_utils.dart
@@ -25,7 +25,7 @@ Chain getMockChain() {
 }
 
 Chains getDefaultChain() {
-  return getDevMode() ? const Chains.mock() : const Chains.topl_mainnet();
+  return getDevMode() ? const Chains.dev_network() : const Chains.topl_mainnet();
 }
 
 Future<int> blockSkipAmount({

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -70,7 +70,7 @@ class AnnulusRouter extends HookConsumerWidget {
             if (chainId == null) {
               vRedirector.to(HomeScreen.chainPath(selectedChain.urlName));
             } else if (chainId != selectedChain.urlName) {
-              final urlChain = ChainsNotifier.standardChains.where((element) => element.hostUrl == chainId).first;
+              final urlChain = ChainsNotifier.standardChains.where((element) => element.urlName == chainId).first;
 
               ref.read(selectedChainProvider.notifier).state = urlChain;
             }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -47,7 +47,10 @@ dependencies:
   freezed_annotation: ^2.2.0
   json_annotation: ^4.8.0
   flutter_hooks: ^0.18.6
-  topl_common: ^2.0.2
+  topl_common: 
+    git: 
+      url: https://github.com/Topl/dart_topl_common.git
+      ref: feath_epoch_data_null
   modal_side_sheet: ^0.0.1
   advanced_datatable: ^0.0.8
   responsive_framework: ^1.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -50,7 +50,7 @@ dependencies:
   topl_common: 
     git: 
       url: https://github.com/Topl/dart_topl_common.git
-      ref: feath_epoch_data_null
+      ref: master
   modal_side_sheet: ^0.0.1
   advanced_datatable: ^0.0.8
   responsive_framework: ^1.0.0


### PR DESCRIPTION
## Description

Fixes the node call and updates the epoch from being used to the block at depth 0 vs just epoch 1.

Fixes # (issue)

DAPP-439

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
