### PR TITLE
bug(Dapp-450): Staking Bugs Fixes in Chain info

### DIFF
--- a/lib/chain/models/chain.dart
+++ b/lib/chain/models/chain.dart
@@ -41,10 +41,10 @@ class Chain with _$Chain {
     required int averageBlockTime,
 
     /// The percentage of staked cypto
-    required double totalStake,
+    required double totalRegisteredStake,
 
     /// Stakes that have been officially recorded on the blockchain
-    required int registeredStakes,
+    required int totalStakes,
 
     /// Portion of a cryptocurrency that is currently being staked
     required int activeStakes,

--- a/lib/chain/providers/chain_statistics_provider.dart
+++ b/lib/chain/providers/chain_statistics_provider.dart
@@ -140,8 +140,8 @@ class ChainStatisticNotifier extends StateNotifier<AsyncValue<Chain>> {
         totalTransactionsInEpoch: totalTransactionsInEpoch,
         height: endHeight,
         averageBlockTime: averageBlockTime,
-        totalStake: activeStakes / totalStakes,
-        registeredStakes: totalStakes,
+        totalRegisteredStake: (activeStakes / totalStakes) * 100,
+        totalStakes: totalStakes,
         activeStakes: activeStakes,
         inactiveStakes: inactiveStakes,
       );

--- a/lib/chain/utils/chain_utils.dart
+++ b/lib/chain/utils/chain_utils.dart
@@ -17,8 +17,8 @@ Chain getMockChain() {
     totalTransactionsInEpoch: 266,
     height: 22100762,
     averageBlockTime: 127,
-    totalStake: .77,
-    registeredStakes: 519,
+    totalRegisteredStake: 77,
+    totalStakes: 519,
     activeStakes: 453,
     inactiveStakes: 66,
   );

--- a/lib/chain/widgets/chain_info/bottom_section/bottom_section.dart
+++ b/lib/chain/widgets/chain_info/bottom_section/bottom_section.dart
@@ -25,28 +25,28 @@ class BottomSection extends StatelessWidget {
       subSection1: SubSection(
         colorTheme: colorTheme,
         statInfoCard1: StatInfoCard(
-          statString: '${chain.totalStake.toString()}%',
-          statSymbol: "Total Stake",
+          statString: '${chain.totalRegisteredStake.toString()}%',
+          statSymbol: Strings.totalRegisteredStake,
           tooltipText: Strings.totalStakeTooltipText,
           isLoading: isLoading,
         ),
         statInfoCard2: StatInfoCard(
-          statString: chain.registeredStakes.toString(),
-          statSymbol: "Registered\nStakes",
-          tooltipText: Strings.registeredStakesTooltipText,
+          statString: chain.totalStakes.toString(),
+          statSymbol: Strings.totalStakes,
+          tooltipText: Strings.totalStakesTooltipText,
           isLoading: isLoading,
         ),
       ),
       subSection2: SubSection(
         colorTheme: colorTheme,
         statInfoCard1: StatInfoCard(
-          statString: '${chain.activeStakes.toString()}%',
-          statSymbol: "Active\nStakes",
+          statString: chain.activeStakes.toString(),
+          statSymbol: Strings.activeStakes,
           tooltipText: Strings.activeStakesTooltipText,
           isLoading: isLoading,
         ),
         statInfoCard2: StatInfoCard(
-          statString: '${chain.inactiveStakes.toString()}%',
+          statString: chain.inactiveStakes.toString(),
           statSymbol: "Inactive\nStakes",
           tooltipText: Strings.invalidStakesTooltipText,
           isLoading: isLoading,

--- a/lib/shared/constants/strings.dart
+++ b/lib/shared/constants/strings.dart
@@ -38,10 +38,8 @@ class Strings {
   static const String footerColumn5Header = 'Subscribe to Our Newsletter';
   static const String footerColumn5Button = 'Submit';
   static const String footerColumn1Item1 = 'Energy Efficient Regularized PoS';
-  static const String footerColumn1Item2 =
-      'UTxO Ledger and Achieving Scalability';
-  static const String footerColumn1Item3 =
-      'User Ecosystem, Standards and Development';
+  static const String footerColumn1Item2 = 'UTxO Ledger and Achieving Scalability';
+  static const String footerColumn1Item3 = 'User Ecosystem, Standards and Development';
   static const String footerColumn1Item4 = 'Tokenomics';
   static const String footerColumn1Item5 = 'Governance';
   static const String footerColumn1Item6 = 'Ribn';
@@ -67,20 +65,17 @@ class Strings {
   static const String footerRightsReserved = '2023 © All rights reserved';
   static const String latestBlocksHeader = 'Latest Blocks';
   static const String eonTooltipText = '';
-  static const String eraTooltipText =
-      'An era is a period during which a specific set of active validators exists.';
+  static const String eraTooltipText = 'An era is a period during which a specific set of active validators exists.';
   static const String epochTooltipText =
       'An epoch or session is one-sixth of an era. \nDuring the last epoch, the active set of the next era is elected. \nAnd after the end of each era, the rewards are calculated and are ready to be distributed to the validators and nominators.';
   static const String totalTransactionTooltipText =
       'Indicates the total number of transactions on the Topl blockchain.';
   static const String heightTooltipText =
       'Indicates the number of blocks that have been confirmed in the entire history of the Topl blockchain.';
-  static const String averageBlockTimeTooltipText =
-      'The average time taken to generate a new block.';
+  static const String averageBlockTimeTooltipText = 'The average time taken to generate a new block.';
   static const String totalStakeTooltipText =
       'Indicates the total percentage of users that have staked on the Topl blockchain to confirm transactions.';
-  static const String registeredStakesTooltipText =
-      'Indicates the total numbers of registered stakes on the Topl blockchain.';
+  static const String totalStakesTooltipText = 'Indicates the total number of stakes on the Topl blockchain';
   static const String activeStakesTooltipText =
       'Indicates the total validators actively being nominated for the current era. \nA single validator is nominated in each era with the full stake. \nThis validator will pay rewards once the payout has been activated at the end of that era.';
   static const String invalidStakesTooltipText =
@@ -114,8 +109,7 @@ class Strings {
   static const String proposition = 'Proposition';
   static const String quantity = 'Quantity';
   static const String name = 'Name';
-  static const String searchHintText =
-      'Search by blocks, transactions, or UTxOs';
+  static const String searchHintText = 'Search by blocks, transactions, or UTxOs';
   static const String averageTxnFee = 'Average Transaction Fee';
   static const String averageTxnFees = 'Average Transaction Fees';
   static const String addNewNetwork = 'Add New Network';
@@ -127,8 +121,7 @@ class Strings {
   static const String requiredField = 'This field is required';
   static const String chainId = 'Chain ID';
   static const String chainIdPlaceHolder = '192.158.0.0';
-  static const String chainIdIdentifierMsg =
-      'The Chain ID is a unique identifier for the network';
+  static const String chainIdIdentifierMsg = 'The Chain ID is a unique identifier for the network';
   static const String selectNetwork = 'Select Network';
   static const String blockExplorerUrl = 'Block Explorer URL (Optional)';
   static const String cancelText = 'Cancel';
@@ -140,4 +133,8 @@ class Strings {
   static const String standardSideSheet = 'Show Standard Side Sheet';
   static const String summary = 'Summary';
   static const String transactions = 'Transactions';
+  static const String totalRegisteredStake = 'Total Registered\nStake';
+  static const String totalStakes = 'Total\nStakes';
+  static const String activeStakes = 'Active\nStakes';
+  static const String inactiveStakes = 'Inactive\nStakes';
 }

--- a/test/chain/chain_info/utils/chain_info_utils.dart
+++ b/test/chain/chain_info/utils/chain_info_utils.dart
@@ -2,6 +2,7 @@ import 'package:flutter_annulus/chain/sections/chain_info.dart';
 import 'package:flutter_annulus/chain/utils/chain_info_calc_utils.dart';
 import 'package:flutter_annulus/chain/widgets/chain_info/stat_info_card.dart';
 import 'package:flutter_annulus/chain/widgets/chain_info/top_chain_info_section.dart';
+import 'package:flutter_annulus/shared/constants/strings.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:topl_common/genus/data_extensions.dart';
 import 'package:topl_common/proto/node/services/bifrost_rpc.pb.dart';
@@ -43,7 +44,10 @@ void confirmChainInfoText({
   final activeStakes = mockChainInfo.epochData.activeStake.toBigInt().toInt();
   final inactiveStakes = mockChainInfo.epochData.inactiveStake.toBigInt().toInt();
   final totalStakes = activeStakes + inactiveStakes;
-  testTextField(StatInfoCard.statInfoItemKey("Registered\nStakes"), "$totalStakes");
-  testTextField(StatInfoCard.statInfoItemKey("Active\nStakes"), "$activeStakes%");
-  testTextField(StatInfoCard.statInfoItemKey("Inactive\nStakes"), "$inactiveStakes%");
+  final totalRegisteredStake = (activeStakes / totalStakes) * 100;
+
+  testTextField(StatInfoCard.statInfoItemKey(Strings.totalStakes), "$totalStakes");
+  testTextField(StatInfoCard.statInfoItemKey(Strings.activeStakes), "$activeStakes");
+  testTextField(StatInfoCard.statInfoItemKey(Strings.inactiveStakes), "$inactiveStakes");
+  testTextField(StatInfoCard.statInfoItemKey(Strings.totalRegisteredStake), "$totalRegisteredStake%");
 }


### PR DESCRIPTION
## Description

This fixes:

Total Stake should be Total Registered Stake which is [Active Stakes / Active + Inactive Stakes] * 100 (a percentage amount)

The above value is a percentage amount and not a float

Registered Stake needs to change to Total Stake which = Active + Inactive Stakes

The tooltip on the Total Stake should show: "Indicates the total number of stakes on the Topl blockchain"

Active Stakes and Inactive Stakes should not have a percentage sign next to them

Fixes # (issue)
DAPP-450

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
